### PR TITLE
Sylius resource type condition

### DIFF
--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\LayoutsSyliusBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+final class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('netgen_layouts_sylius');
+
+        /** @var \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $rootNode */
+        $rootNode = $treeBuilder->getRootNode();
+        $this->addResourceTypeConditionConfiguration($rootNode);
+
+        return $treeBuilder;
+    }
+
+    private function addResourceTypeConditionConfiguration(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('resource_type_condition')
+                    ->children()
+                        ->arrayNode('available_resources')
+                            ->prototype('scalar')
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+}

--- a/bundle/DependencyInjection/NetgenLayoutsSyliusExtension.php
+++ b/bundle/DependencyInjection/NetgenLayoutsSyliusExtension.php
@@ -36,12 +36,21 @@ final class NetgenLayoutsSyliusExtension extends Extension implements PrependExt
         );
 
         $loader->load('services/**/*.yaml', 'glob');
-        $loader->load('default_settings.yaml');
+        $loader->load('default_parameters.yaml');
+
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $container->setParameter(
+            'netgen_layouts.sylius.condition.resource_types',
+            $config['resource_type_condition']['available_resources'],
+        );
     }
 
     public function prepend(ContainerBuilder $container): void
     {
         $prependConfigs = [
+            'default_settings.yaml' => 'netgen_layouts_sylius',
             'liip_imagine.yaml' => 'liip_imagine',
             'design.yaml' => 'netgen_layouts',
             'value_types.yaml' => 'netgen_layouts',

--- a/bundle/EventDispatcher/SyliusEventDispatcher.php
+++ b/bundle/EventDispatcher/SyliusEventDispatcher.php
@@ -15,8 +15,8 @@ use function sprintf;
 final class SyliusEventDispatcher implements EventDispatcherInterface
 {
     public function __construct(
-        private readonly EventDispatcherInterface $innerEventDispatcher,
-        private readonly SymfonyEventDispatcherInterface $eventDispatcher,
+        private EventDispatcherInterface $innerEventDispatcher,
+        private SymfonyEventDispatcherInterface $eventDispatcher,
     ) {}
 
     public function dispatch(string $eventName, RequestConfiguration $requestConfiguration, ResourceInterface $resource): ResourceControllerEvent

--- a/bundle/EventDispatcher/SyliusEventDispatcher.php
+++ b/bundle/EventDispatcher/SyliusEventDispatcher.php
@@ -17,8 +17,7 @@ final class SyliusEventDispatcher implements EventDispatcherInterface
     public function __construct(
         private readonly EventDispatcherInterface $innerEventDispatcher,
         private readonly SymfonyEventDispatcherInterface $eventDispatcher,
-    ) {
-    }
+    ) {}
 
     public function dispatch(string $eventName, RequestConfiguration $requestConfiguration, ResourceInterface $resource): ResourceControllerEvent
     {

--- a/bundle/EventDispatcher/SyliusEventDispatcher.php
+++ b/bundle/EventDispatcher/SyliusEventDispatcher.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\LayoutsSyliusBundle\EventDispatcher;
+
+use Sylius\Bundle\ResourceBundle\Controller\EventDispatcherInterface;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
+use Sylius\Component\Resource\Model\ResourceInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as SymfonyEventDispatcherInterface;
+
+use function sprintf;
+
+final class SyliusEventDispatcher implements EventDispatcherInterface
+{
+    public function __construct(
+        private readonly EventDispatcherInterface $innerEventDispatcher,
+        private readonly SymfonyEventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    public function dispatch(string $eventName, RequestConfiguration $requestConfiguration, ResourceInterface $resource): ResourceControllerEvent
+    {
+        $event = $this->innerEventDispatcher->dispatch($eventName, $requestConfiguration, $resource);
+
+        $this->eventDispatcher->dispatch($event, sprintf('sylius.resource.%s', $eventName));
+
+        return $event;
+    }
+
+    public function dispatchMultiple(string $eventName, RequestConfiguration $requestConfiguration, $resources): ResourceControllerEvent
+    {
+        $event = $this->innerEventDispatcher->dispatchMultiple($eventName, $requestConfiguration, $resources);
+
+        $this->eventDispatcher->dispatch($event, sprintf('sylius.resource.%s', $eventName));
+
+        return $event;
+    }
+
+    public function dispatchPreEvent(string $eventName, RequestConfiguration $requestConfiguration, ResourceInterface $resource): ResourceControllerEvent
+    {
+        $event = $this->innerEventDispatcher->dispatchPreEvent($eventName, $requestConfiguration, $resource);
+
+        $this->eventDispatcher->dispatch($event, sprintf('sylius.resource.pre_%s', $eventName));
+
+        return $event;
+    }
+
+    public function dispatchPostEvent(string $eventName, RequestConfiguration $requestConfiguration, ResourceInterface $resource): ResourceControllerEvent
+    {
+        $event = $this->innerEventDispatcher->dispatchPostEvent($eventName, $requestConfiguration, $resource);
+
+        $this->eventDispatcher->dispatch($event, sprintf('sylius.resource.post_%s', $eventName));
+
+        return $event;
+    }
+
+    public function dispatchInitializeEvent(string $eventName, RequestConfiguration $requestConfiguration, ResourceInterface $resource): ResourceControllerEvent
+    {
+        $event = $this->innerEventDispatcher->dispatchInitializeEvent($eventName, $requestConfiguration, $resource);
+
+        $this->eventDispatcher->dispatch($event, sprintf('sylius.resource.initialize_%s', $eventName));
+
+        return $event;
+    }
+}

--- a/bundle/EventListener/Shop/ProductIndexListener.php
+++ b/bundle/EventListener/Shop/ProductIndexListener.php
@@ -53,6 +53,7 @@ final class ProductIndexListener implements EventSubscriberInterface
         }
 
         $currentRequest->attributes->set('nglayouts_sylius_taxon', $taxon);
+        $currentRequest->attributes->set('nglayouts_sylius_resource', $taxon);
         // We set context here instead in a ContextProvider, since sylius.taxon.show
         // event happens too late, after onKernelRequest event has already been executed
         $this->context->set('sylius_taxon_id', (int) $taxon->getId());

--- a/bundle/EventListener/Shop/ResourceShowListener.php
+++ b/bundle/EventListener/Shop/ResourceShowListener.php
@@ -12,9 +12,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 final class ResourceShowListener implements EventSubscriberInterface
 {
-    public function __construct(private RequestStack $requestStack)
-    {
-    }
+    public function __construct(private RequestStack $requestStack) {}
 
     public static function getSubscribedEvents(): array
     {

--- a/bundle/EventListener/Shop/ResourceShowListener.php
+++ b/bundle/EventListener/Shop/ResourceShowListener.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\LayoutsSyliusBundle\EventListener\Shop;
+
+use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
+use Sylius\Component\Resource\Model\ResourceInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class ResourceShowListener implements EventSubscriberInterface
+{
+    public function __construct(private RequestStack $requestStack)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return ['sylius.resource.show' => 'onResourceShow'];
+    }
+
+    /**
+     * Sets the currently displayed Sylius resource to the request,
+     * to be able to match with layout resolver.
+     */
+    public function onResourceShow(ResourceControllerEvent $event): void
+    {
+        $resource = $event->getSubject();
+        if (!$resource instanceof ResourceInterface) {
+            return;
+        }
+
+        $currentRequest = $this->requestStack->getCurrentRequest();
+        if ($currentRequest instanceof Request) {
+            $currentRequest->attributes->set('nglayouts_sylius_resource', $resource);
+        }
+    }
+}

--- a/bundle/Resources/config/default_parameters.yaml
+++ b/bundle/Resources/config/default_parameters.yaml
@@ -1,0 +1,2 @@
+parameters:
+    netgen_layouts.sylius.admin.pagelayout: '@@NetgenLayoutsSylius/admin/pagelayout.html.twig'

--- a/bundle/Resources/config/default_settings.yaml
+++ b/bundle/Resources/config/default_settings.yaml
@@ -1,2 +1,4 @@
-parameters:
-    netgen_layouts.sylius.admin.pagelayout: '@@NetgenLayoutsSylius/admin/pagelayout.html.twig'
+resource_type_condition:
+    available_resources:
+        Sylius\Component\Product\Model\Product: product
+        Sylius\Component\Taxonomy\Model\Taxon: taxon

--- a/bundle/Resources/config/default_settings.yaml
+++ b/bundle/Resources/config/default_settings.yaml
@@ -1,4 +1,4 @@
 resource_type_condition:
     available_resources:
-        Sylius\Component\Product\Model\Product: product
-        Sylius\Component\Taxonomy\Model\Taxon: taxon
+        Sylius\Component\Product\Model\ProductInterface: product
+        Sylius\Component\Taxonomy\Model\TaxonInterface: taxon

--- a/bundle/Resources/config/services/event_dispatchers.yaml
+++ b/bundle/Resources/config/services/event_dispatchers.yaml
@@ -1,0 +1,7 @@
+services:
+    netgen_layouts.sylius.event_dispatcher.sylius_event_dispatcher:
+        class: Netgen\Bundle\LayoutsSyliusBundle\EventDispatcher\SyliusEventDispatcher
+        decorates: sylius.resource_controller.event_dispatcher
+        arguments:
+            - '@.inner'
+            - '@event_dispatcher'

--- a/bundle/Resources/config/services/event_listeners.yaml
+++ b/bundle/Resources/config/services/event_listeners.yaml
@@ -13,6 +13,13 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    netgen_layouts.sylius.event_listener.shop.resource_show:
+        class: Netgen\Bundle\LayoutsSyliusBundle\EventListener\Shop\ResourceShowListener
+        arguments:
+            - "@request_stack"
+        tags:
+            - { name: kernel.event_subscriber }
+
     netgen_layouts.sylius.event_listener.shop.product_show:
         class: Netgen\Bundle\LayoutsSyliusBundle\EventListener\Shop\ProductShowListener
         arguments:

--- a/bundle/Resources/config/services/layout_resolver.yaml
+++ b/bundle/Resources/config/services/layout_resolver.yaml
@@ -69,3 +69,17 @@ services:
             - "@sylius.repository.locale"
         tags:
             - { name: netgen_layouts.condition_type.form_mapper, condition_type: sylius_locale }
+
+    netgen_layouts.sylius.layout_resolver.condition_type.resource_type:
+        class: Netgen\Layouts\Sylius\Layout\Resolver\ConditionType\ResourceType
+        arguments:
+            - "%netgen_layouts.sylius.condition.resource_types%"
+        tags:
+            - { name: netgen_layouts.condition_type }
+
+    netgen_layouts.sylius.layout_resolver.condition_type.form_mapper.resource_type:
+        class: Netgen\Layouts\Sylius\Layout\Resolver\Form\ConditionType\Mapper\ResourceType
+        arguments:
+            - "%netgen_layouts.sylius.condition.resource_types%"
+        tags:
+            - { name: netgen_layouts.condition_type.form_mapper, condition_type: sylius_resource_type }

--- a/bundle/Resources/config/services/validators.yaml
+++ b/bundle/Resources/config/services/validators.yaml
@@ -26,3 +26,10 @@ services:
             - "@sylius.repository.locale"
         tags:
             - { name: validator.constraint_validator, alias: nglayouts_sylius_locale }
+
+    netgen_layouts.sylius.validator.resource_type:
+        class: Netgen\Layouts\Sylius\Validator\ResourceTypeValidator
+        arguments:
+            - "%netgen_layouts.sylius.condition.resource_types%"
+        tags:
+            - { name: validator.constraint_validator, alias: nglayouts_sylius_resource_type }

--- a/bundle/Resources/config/view/rule_condition_view.yaml
+++ b/bundle/Resources/config/view/rule_condition_view.yaml
@@ -9,3 +9,7 @@ view:
                 template: "@NetgenLayoutsSylius/admin/layout_resolver/condition/value/sylius_locale.html.twig"
                 match:
                     rule_condition\type: sylius_locale
+            sylius_resource_type:
+                template: "@NetgenLayoutsSylius/admin/layout_resolver/condition/value/sylius_resource_type.html.twig"
+                match:
+                    rule_condition\type: sylius_resource_type

--- a/bundle/Resources/translations/nglayouts.en.yaml
+++ b/bundle/Resources/translations/nglayouts.en.yaml
@@ -12,3 +12,4 @@ layout_resolver.target.sylius_taxon_product: 'Sylius taxon products'
 
 layout_resolver.condition.sylius_channel: 'Sylius channel'
 layout_resolver.condition.sylius_locale: 'Sylius locale'
+layout_resolver.condition.sylius_resource_type: 'Sylius resource type'

--- a/bundle/Resources/translations/validators.en.yaml
+++ b/bundle/Resources/translations/validators.en.yaml
@@ -2,3 +2,4 @@ netgen_layouts.sylius.product.product_not_found: 'Product with ID %productId% do
 netgen_layouts.sylius.taxon.taxon_not_found: 'Taxon with ID %taxonId% does not exist.'
 netgen_layouts.sylius.channel.channel_not_found: 'Channel %channel% does not exist.'
 netgen_layouts.sylius.locale.locale_not_found: 'Locale %locale% does not exist.'
+netgen_layouts.sylius.resource_type.type_not_found: 'Resource type %resource_type% does not exist.'

--- a/bundle/Resources/views/admin/layout_resolver/condition/value/sylius_resource_type.html.twig
+++ b/bundle/Resources/views/admin/layout_resolver/condition/value/sylius_resource_type.html.twig
@@ -1,0 +1,7 @@
+{% set types = [] %}
+
+{% for type in condition.value %}
+    {% set types = types|merge([type|capitalize|replace({'-': ' ', '_': ' '})]) %}
+{% endfor %}
+
+{{ types|join(', ') }}

--- a/lib/Layout/Resolver/ConditionType/ResourceType.php
+++ b/lib/Layout/Resolver/ConditionType/ResourceType.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Layout\Resolver\ConditionType;
+
+use Netgen\Layouts\Layout\Resolver\ConditionType;
+use Netgen\Layouts\Sylius\Validator\Constraint as SyliusConstraints;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\Constraints;
+
+use function array_flip;
+use function array_map;
+use function is_a;
+
+final class ResourceType extends ConditionType
+{
+    /**
+     * @param array<string, string> $allowedResources
+     */
+    public function __construct(private readonly array $allowedResources)
+    {
+    }
+
+    public static function getType(): string
+    {
+        return 'sylius_resource_type';
+    }
+
+    public function getConstraints(): array
+    {
+        return [
+            new Constraints\NotBlank(),
+            new Constraints\All(
+                [
+                    'constraints' => [
+                        new Constraints\Type(['type' => 'string']),
+                        new SyliusConstraints\ResourceType(),
+                    ],
+                ],
+            ),
+        ];
+    }
+
+    public function matches(Request $request, mixed $value): bool
+    {
+        $resource = $request->attributes->get('nglayouts_sylius_resource');
+
+        $allowedClasses = array_map(fn (string $value): string => array_flip($this->allowedResources)[$value], $value);
+
+        foreach ($allowedClasses as $allowedClass) {
+            if (is_a($resource, $allowedClass)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/lib/Layout/Resolver/ConditionType/ResourceType.php
+++ b/lib/Layout/Resolver/ConditionType/ResourceType.php
@@ -51,6 +51,7 @@ final class ResourceType extends ConditionType
             array_map(fn (string $type): ?string => array_flip($this->allowedResources)[$type] ?? null, $value),
         );
 
+        /** @var class-string $allowedClass */
         foreach ($allowedClasses as $allowedClass) {
             if (is_a($resource, $allowedClass)) {
                 return true;

--- a/lib/Layout/Resolver/ConditionType/ResourceType.php
+++ b/lib/Layout/Resolver/ConditionType/ResourceType.php
@@ -19,9 +19,7 @@ final class ResourceType extends ConditionType
     /**
      * @param array<string, string> $allowedResources
      */
-    public function __construct(private readonly array $allowedResources)
-    {
-    }
+    public function __construct(private readonly array $allowedResources) {}
 
     public static function getType(): string
     {

--- a/lib/Layout/Resolver/ConditionType/ResourceType.php
+++ b/lib/Layout/Resolver/ConditionType/ResourceType.php
@@ -9,6 +9,7 @@ use Netgen\Layouts\Sylius\Validator\Constraint as SyliusConstraints;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Constraints;
 
+use function array_filter;
 use function array_flip;
 use function array_map;
 use function is_a;
@@ -46,7 +47,9 @@ final class ResourceType extends ConditionType
     {
         $resource = $request->attributes->get('nglayouts_sylius_resource');
 
-        $allowedClasses = array_map(fn (string $value): string => array_flip($this->allowedResources)[$value], $value);
+        $allowedClasses = array_filter(
+            array_map(fn (string $type): ?string => array_flip($this->allowedResources)[$type] ?? null, $value),
+        );
 
         foreach ($allowedClasses as $allowedClass) {
             if (is_a($resource, $allowedClass)) {

--- a/lib/Layout/Resolver/ConditionType/ResourceType.php
+++ b/lib/Layout/Resolver/ConditionType/ResourceType.php
@@ -19,7 +19,7 @@ final class ResourceType extends ConditionType
     /**
      * @param array<string, string> $allowedResources
      */
-    public function __construct(private readonly array $allowedResources) {}
+    public function __construct(private array $allowedResources) {}
 
     public static function getType(): string
     {

--- a/lib/Layout/Resolver/Form/ConditionType/Mapper/ResourceType.php
+++ b/lib/Layout/Resolver/Form/ConditionType/Mapper/ResourceType.php
@@ -15,9 +15,7 @@ final class ResourceType extends Mapper
     /**
      * @param array<string, string> $allowedResources
      */
-    public function __construct(private readonly array $allowedResources)
-    {
-    }
+    public function __construct(private readonly array $allowedResources) {}
 
     public function getFormType(): string
     {

--- a/lib/Layout/Resolver/Form/ConditionType/Mapper/ResourceType.php
+++ b/lib/Layout/Resolver/Form/ConditionType/Mapper/ResourceType.php
@@ -7,6 +7,7 @@ namespace Netgen\Layouts\Sylius\Layout\Resolver\Form\ConditionType\Mapper;
 use Netgen\Layouts\Layout\Resolver\Form\ConditionType\Mapper;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
+use function array_values;
 use function str_replace;
 use function ucfirst;
 
@@ -25,25 +26,12 @@ final class ResourceType extends Mapper
     public function getFormOptions(): array
     {
         return [
-            'choices' => $this->getResourceTypeList(),
+            'choices' => array_values($this->allowedResources),
+            'choice_label' => fn (string $type): string => $this->humanizeType($type),
             'choice_translation_domain' => false,
             'multiple' => true,
             'expanded' => true,
         ];
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private function getResourceTypeList(): array
-    {
-        $resourceTypeList = [];
-
-        foreach ($this->allowedResources as $type) {
-            $resourceTypeList[$this->humanizeType($type)] = $type;
-        }
-
-        return $resourceTypeList;
     }
 
     private function humanizeType(string $type): string

--- a/lib/Layout/Resolver/Form/ConditionType/Mapper/ResourceType.php
+++ b/lib/Layout/Resolver/Form/ConditionType/Mapper/ResourceType.php
@@ -16,7 +16,7 @@ final class ResourceType extends Mapper
     /**
      * @param array<string, string> $allowedResources
      */
-    public function __construct(private readonly array $allowedResources) {}
+    public function __construct(private array $allowedResources) {}
 
     public function getFormType(): string
     {

--- a/lib/Layout/Resolver/Form/ConditionType/Mapper/ResourceType.php
+++ b/lib/Layout/Resolver/Form/ConditionType/Mapper/ResourceType.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Layout\Resolver\Form\ConditionType\Mapper;
+
+use Netgen\Layouts\Layout\Resolver\Form\ConditionType\Mapper;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+
+use function str_replace;
+use function ucfirst;
+
+final class ResourceType extends Mapper
+{
+    /**
+     * @param array<string, string> $allowedResources
+     */
+    public function __construct(private readonly array $allowedResources)
+    {
+    }
+
+    public function getFormType(): string
+    {
+        return ChoiceType::class;
+    }
+
+    public function getFormOptions(): array
+    {
+        return [
+            'choices' => $this->getResourceTypeList(),
+            'choice_translation_domain' => false,
+            'multiple' => true,
+            'expanded' => true,
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getResourceTypeList(): array
+    {
+        $resourceTypeList = [];
+
+        foreach ($this->allowedResources as $type) {
+            $resourceTypeList[$this->humanizeType($type)] = $type;
+        }
+
+        return $resourceTypeList;
+    }
+
+    private function humanizeType(string $type): string
+    {
+        return ucfirst(str_replace(['-', '_'], ' ', $type));
+    }
+}

--- a/lib/Validator/Constraint/ResourceType.php
+++ b/lib/Validator/Constraint/ResourceType.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Validator\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+final class ResourceType extends Constraint
+{
+    public string $message = 'netgen_layouts.sylius.resource_type.type_not_found';
+
+    public function validatedBy(): string
+    {
+        return 'nglayouts_sylius_resource_type';
+    }
+}

--- a/lib/Validator/ResourceTypeValidator.php
+++ b/lib/Validator/ResourceTypeValidator.php
@@ -17,9 +17,7 @@ final class ResourceTypeValidator extends ConstraintValidator
     /**
      * @param array<string, string> $allowedResources
      */
-    public function __construct(private readonly array $allowedResources)
-    {
-    }
+    public function __construct(private readonly array $allowedResources) {}
 
     public function validate(mixed $value, Constraint $constraint): void
     {

--- a/lib/Validator/ResourceTypeValidator.php
+++ b/lib/Validator/ResourceTypeValidator.php
@@ -17,7 +17,7 @@ final class ResourceTypeValidator extends ConstraintValidator
     /**
      * @param array<string, string> $allowedResources
      */
-    public function __construct(private readonly array $allowedResources) {}
+    public function __construct(private array $allowedResources) {}
 
     public function validate(mixed $value, Constraint $constraint): void
     {

--- a/lib/Validator/ResourceTypeValidator.php
+++ b/lib/Validator/ResourceTypeValidator.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Validator;
+
+use Netgen\Layouts\Sylius\Validator\Constraint\ResourceType;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+use function in_array;
+use function is_string;
+
+final class ResourceTypeValidator extends ConstraintValidator
+{
+    /**
+     * @param array<string, string> $allowedResources
+     */
+    public function __construct(private readonly array $allowedResources)
+    {
+    }
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        if (!$constraint instanceof ResourceType) {
+            throw new UnexpectedTypeException($constraint, ResourceType::class);
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        if (!in_array($value, $this->allowedResources, true)) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('%resource_type%', $value)
+                ->addViolation();
+        }
+    }
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -41,6 +41,18 @@
                 <file name="lib/Security/Authorization/Voter/AdminAccessVoter.php" />
             </errorLevel>
         </LessSpecificImplementedReturnType>
+
+        <PossiblyNullReference>
+            <errorLevel type="suppress">
+                <file name="bundle/DependencyInjection/Configuration.php" />
+            </errorLevel>
+        </PossiblyNullReference>
+
+        <UndefinedInterfaceMethod>
+            <errorLevel type="suppress">
+                <file name="bundle/DependencyInjection/Configuration.php" />
+            </errorLevel>
+        </UndefinedInterfaceMethod>
     </issueHandlers>
 
     <plugins>

--- a/tests/bundle/EventDispatcher/SyliusEventDispatcherTest.php
+++ b/tests/bundle/EventDispatcher/SyliusEventDispatcherTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\LayoutsSyliusBundle\Tests\EventDispatcher;
+
+use Netgen\Bundle\LayoutsSyliusBundle\EventDispatcher\SyliusEventDispatcher;
+use Netgen\Layouts\Sylius\Tests\Stubs\Product;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\ResourceBundle\Controller\EventDispatcherInterface;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as SymfonyEventDispatcherInterface;
+
+#[CoversClass(SyliusEventDispatcher::class)]
+final class SyliusEventDispatcherTest extends TestCase
+{
+    private SyliusEventDispatcher $dispatcher;
+
+    private MockObject&EventDispatcherInterface $innerEventDispatcherMock;
+
+    private MockObject&SymfonyEventDispatcherInterface $eventDispatcherMock;
+
+    protected function setUp(): void
+    {
+        $this->innerEventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
+        $this->eventDispatcherMock = $this->createMock(SymfonyEventDispatcherInterface::class);
+
+        $this->dispatcher = new SyliusEventDispatcher(
+            $this->innerEventDispatcherMock,
+            $this->eventDispatcherMock,
+        );
+    }
+
+    public function testDispatch(): void
+    {
+        $eventName = 'show';
+        $requestConfiguration = $this->createMock(RequestConfiguration::class);
+        $resource = new Product(5);
+
+        $event = new ResourceControllerEvent();
+
+        $this->innerEventDispatcherMock
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with($eventName, $requestConfiguration, $resource)
+            ->willReturn($event);
+
+        $this->eventDispatcherMock
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with($event, 'sylius.resource.show')
+            ->willReturn($event);
+
+        self::assertSame(
+            $event,
+            $this->dispatcher->dispatch($eventName, $requestConfiguration, $resource),
+        );
+    }
+
+    public function testDispatchMultiple(): void
+    {
+        $eventName = 'show';
+        $requestConfiguration = $this->createMock(RequestConfiguration::class);
+        $resource = new Product(5);
+
+        $event = new ResourceControllerEvent();
+
+        $this->innerEventDispatcherMock
+            ->expects(self::once())
+            ->method('dispatchMultiple')
+            ->with($eventName, $requestConfiguration, $resource)
+            ->willReturn($event);
+
+        $this->eventDispatcherMock
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with($event, 'sylius.resource.show')
+            ->willReturn($event);
+
+        self::assertSame(
+            $event,
+            $this->dispatcher->dispatchMultiple($eventName, $requestConfiguration, $resource),
+        );
+    }
+
+    public function testDispatchPreEvent(): void
+    {
+        $eventName = 'show';
+        $requestConfiguration = $this->createMock(RequestConfiguration::class);
+        $resource = new Product(5);
+
+        $event = new ResourceControllerEvent();
+
+        $this->innerEventDispatcherMock
+            ->expects(self::once())
+            ->method('dispatchPreEvent')
+            ->with($eventName, $requestConfiguration, $resource)
+            ->willReturn($event);
+
+        $this->eventDispatcherMock
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with($event, 'sylius.resource.pre_show')
+            ->willReturn($event);
+
+        self::assertSame(
+            $event,
+            $this->dispatcher->dispatchPreEvent($eventName, $requestConfiguration, $resource),
+        );
+    }
+
+    public function testDispatchPostEvent(): void
+    {
+        $eventName = 'show';
+        $requestConfiguration = $this->createMock(RequestConfiguration::class);
+        $resource = new Product(5);
+
+        $event = new ResourceControllerEvent();
+
+        $this->innerEventDispatcherMock
+            ->expects(self::once())
+            ->method('dispatchPostEvent')
+            ->with($eventName, $requestConfiguration, $resource)
+            ->willReturn($event);
+
+        $this->eventDispatcherMock
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with($event, 'sylius.resource.post_show')
+            ->willReturn($event);
+
+        self::assertSame(
+            $event,
+            $this->dispatcher->dispatchPostEvent($eventName, $requestConfiguration, $resource),
+        );
+    }
+
+    public function testDispatchInitializeEvent(): void
+    {
+        $eventName = 'show';
+        $requestConfiguration = $this->createMock(RequestConfiguration::class);
+        $resource = new Product(5);
+
+        $event = new ResourceControllerEvent();
+
+        $this->innerEventDispatcherMock
+            ->expects(self::once())
+            ->method('dispatchInitializeEvent')
+            ->with($eventName, $requestConfiguration, $resource)
+            ->willReturn($event);
+
+        $this->eventDispatcherMock
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with($event, 'sylius.resource.initialize_show')
+            ->willReturn($event);
+
+        self::assertSame(
+            $event,
+            $this->dispatcher->dispatchInitializeEvent($eventName, $requestConfiguration, $resource),
+        );
+    }
+}

--- a/tests/bundle/EventDispatcher/SyliusEventDispatcherTest.php
+++ b/tests/bundle/EventDispatcher/SyliusEventDispatcherTest.php
@@ -19,7 +19,7 @@ final class SyliusEventDispatcherTest extends TestCase
 {
     private SyliusEventDispatcher $dispatcher;
 
-    private MockObject&EventDispatcherInterface $innerEventDispatcherMock;
+    private EventDispatcherInterface&MockObject $innerEventDispatcherMock;
 
     private MockObject&SymfonyEventDispatcherInterface $eventDispatcherMock;
 

--- a/tests/bundle/EventListener/Admin/MainMenuBuilderListenerTest.php
+++ b/tests/bundle/EventListener/Admin/MainMenuBuilderListenerTest.php
@@ -22,7 +22,7 @@ final class MainMenuBuilderListenerTest extends TestCase
 {
     private MainMenuBuilderListener $listener;
 
-    private MockObject&AuthorizationCheckerInterface $authCheckerMock;
+    private AuthorizationCheckerInterface&MockObject $authCheckerMock;
 
     protected function setUp(): void
     {

--- a/tests/bundle/EventListener/Shop/ProductIndexListenerTest.php
+++ b/tests/bundle/EventListener/Shop/ProductIndexListenerTest.php
@@ -75,6 +75,7 @@ final class ProductIndexListenerTest extends TestCase
         $this->listener->onProductIndex($event);
 
         self::assertSame($taxon, $request->attributes->get('nglayouts_sylius_taxon'));
+        self::assertSame($taxon, $request->attributes->get('nglayouts_sylius_resource'));
 
         self::assertTrue($this->context->has('sylius_taxon_id'));
         self::assertSame(42, $this->context->get('sylius_taxon_id'));
@@ -105,6 +106,7 @@ final class ProductIndexListenerTest extends TestCase
         $this->listener->onProductIndex($event);
 
         self::assertFalse($request->attributes->has('nglayouts_sylius_taxon'));
+        self::assertFalse($request->attributes->has('nglayouts_sylius_resource'));
         self::assertFalse($this->context->has('sylius_taxon_id'));
     }
 
@@ -125,6 +127,7 @@ final class ProductIndexListenerTest extends TestCase
         $this->listener->onProductIndex($event);
 
         self::assertFalse($request->attributes->has('nglayouts_sylius_taxon'));
+        self::assertFalse($request->attributes->has('nglayouts_sylius_resource'));
         self::assertFalse($this->context->has('sylius_taxon_id'));
     }
 }

--- a/tests/bundle/EventListener/Shop/ProductIndexListenerTest.php
+++ b/tests/bundle/EventListener/Shop/ProductIndexListenerTest.php
@@ -23,7 +23,7 @@ final class ProductIndexListenerTest extends TestCase
 
     private MockObject&TaxonRepositoryInterface $taxonRepositoryMock;
 
-    private MockObject&LocaleContextInterface $localeContextMock;
+    private LocaleContextInterface&MockObject $localeContextMock;
 
     private RequestStack $requestStack;
 

--- a/tests/bundle/EventListener/Shop/ResourceShowListenerTest.php
+++ b/tests/bundle/EventListener/Shop/ResourceShowListenerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\LayoutsSyliusBundle\Tests\EventListener\Shop;
+
+use Netgen\Bundle\LayoutsSyliusBundle\EventListener\Shop\ResourceShowListener;
+use Netgen\Layouts\Sylius\Tests\Stubs\Product;
+use Netgen\Layouts\Sylius\Tests\Stubs\Taxon;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+#[CoversClass(ResourceShowListener::class)]
+final class ResourceShowListenerTest extends TestCase
+{
+    private ResourceShowListener $listener;
+
+    private RequestStack $requestStack;
+
+    protected function setUp(): void
+    {
+        $this->requestStack = new RequestStack();
+
+        $this->listener = new ResourceShowListener($this->requestStack);
+    }
+
+    public function testGetSubscribedEvents(): void
+    {
+        self::assertSame(
+            ['sylius.resource.show' => 'onResourceShow'],
+            $this->listener::getSubscribedEvents(),
+        );
+    }
+
+    public function testOnResourceShowProduct(): void
+    {
+        $request = Request::create('/');
+        $this->requestStack->push($request);
+
+        $product = new Product(42);
+        $event = new ResourceControllerEvent($product);
+        $this->listener->onResourceShow($event);
+
+        self::assertSame($product, $request->attributes->get('nglayouts_sylius_resource'));
+    }
+
+    public function testOnResourceShowTaxon(): void
+    {
+        $request = Request::create('/');
+        $this->requestStack->push($request);
+
+        $taxon = new Taxon(2);
+        $event = new ResourceControllerEvent($taxon);
+        $this->listener->onResourceShow($event);
+
+        self::assertSame($taxon, $request->attributes->get('nglayouts_sylius_resource'));
+    }
+
+    public function testOnResourceShowInvalid(): void
+    {
+        $request = Request::create('/');
+        $this->requestStack->push($request);
+
+        $event = new ResourceControllerEvent([]);
+        $this->listener->onResourceShow($event);
+
+        self::assertFalse($request->attributes->has('nglayouts_sylius_resource'));
+    }
+}

--- a/tests/bundle/Templating/Twig/Runtime/SyliusRuntimeTest.php
+++ b/tests/bundle/Templating/Twig/Runtime/SyliusRuntimeTest.php
@@ -25,7 +25,7 @@ final class SyliusRuntimeTest extends TestCase
 
     private MockObject&TaxonRepositoryInterface $taxonRepositoryMock;
 
-    private MockObject&ChannelRepositoryInterface $channelRepositoryMock;
+    private ChannelRepositoryInterface&MockObject $channelRepositoryMock;
 
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject&\Sylius\Component\Resource\Repository\RepositoryInterface<\Sylius\Component\Locale\Model\LocaleInterface>

--- a/tests/lib/Layout/Resolver/ConditionType/ChannelTest.php
+++ b/tests/lib/Layout/Resolver/ConditionType/ChannelTest.php
@@ -20,9 +20,9 @@ use Symfony\Component\Validator\Validation;
 #[CoversClass(Channel::class)]
 final class ChannelTest extends TestCase
 {
-    private MockObject&ChannelContextInterface $channelContextMock;
+    private ChannelContextInterface&MockObject $channelContextMock;
 
-    private MockObject&ChannelRepositoryInterface $channelRepositoryMock;
+    private ChannelRepositoryInterface&MockObject $channelRepositoryMock;
 
     private Channel $conditionType;
 

--- a/tests/lib/Layout/Resolver/ConditionType/ResourceTypeTest.php
+++ b/tests/lib/Layout/Resolver/ConditionType/ResourceTypeTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Tests\Layout\Resolver\ConditionType;
+
+use Netgen\Layouts\Sylius\Layout\Resolver\ConditionType\ResourceType;
+use Netgen\Layouts\Sylius\Tests\Stubs\Product;
+use Netgen\Layouts\Sylius\Tests\Stubs\Taxon;
+use Netgen\Layouts\Sylius\Tests\Validator\SettingsValidatorFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[CoversClass(ResourceType::class)]
+final class ResourceTypeTest extends TestCase
+{
+    private ResourceType $conditionType;
+
+    private ValidatorInterface $validator;
+
+    protected function setUp(): void
+    {
+        $allowedResources = [
+            'Sylius\Component\Product\Model\ProductInterface' => 'product',
+            'Sylius\Component\Taxonomy\Model\TaxonInterface' => 'taxon',
+        ];
+
+        $this->validator = Validation::createValidatorBuilder()
+            ->setConstraintValidatorFactory(new SettingsValidatorFactory($allowedResources))
+            ->getValidator();
+
+        $this->conditionType = new ResourceType($allowedResources);
+    }
+
+    public function testGetType(): void
+    {
+        self::assertSame('sylius_resource_type', $this->conditionType::getType());
+    }
+
+    public function testValidationValid(): void
+    {
+        $errors = $this->validator->validate(['product'], $this->conditionType->getConstraints());
+        self::assertCount(0, $errors);
+    }
+
+    public function testValidationNonExisting(): void
+    {
+        $errors = $this->validator->validate(['category'], $this->conditionType->getConstraints());
+        self::assertCount(1, $errors);
+    }
+
+    public function testValidationInvalidValue(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+
+        $this->validator->validate([5], $this->conditionType->getConstraints());
+    }
+
+    public function testMatchesProduct(): void
+    {
+        $request = Request::create('/');
+        $product = new Product(3);
+        $request->attributes->set('nglayouts_sylius_resource', $product);
+
+        self::assertTrue($this->conditionType->matches($request, ['product']));
+        self::assertTrue($this->conditionType->matches($request, ['product', 'taxon']));
+        self::assertFalse($this->conditionType->matches($request, ['taxon']));
+        self::assertFalse($this->conditionType->matches($request, ['taxon', 'category']));
+    }
+
+    public function testMatchesTaxon(): void
+    {
+        $request = Request::create('/');
+        $taxon = new Taxon(3);
+        $request->attributes->set('nglayouts_sylius_resource', $taxon);
+
+        self::assertTrue($this->conditionType->matches($request, ['taxon']));
+        self::assertTrue($this->conditionType->matches($request, ['product', 'taxon']));
+        self::assertFalse($this->conditionType->matches($request, ['product']));
+        self::assertFalse($this->conditionType->matches($request, ['product', 'category']));
+    }
+}

--- a/tests/lib/Layout/Resolver/ConditionType/ResourceTypeTest.php
+++ b/tests/lib/Layout/Resolver/ConditionType/ResourceTypeTest.php
@@ -10,6 +10,8 @@ use Netgen\Layouts\Sylius\Tests\Stubs\Taxon;
 use Netgen\Layouts\Sylius\Tests\Validator\SettingsValidatorFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Sylius\Component\Product\Model\ProductInterface;
+use Sylius\Component\Taxonomy\Model\TaxonInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Validation;
@@ -25,8 +27,8 @@ final class ResourceTypeTest extends TestCase
     protected function setUp(): void
     {
         $allowedResources = [
-            'Sylius\Component\Product\Model\ProductInterface' => 'product',
-            'Sylius\Component\Taxonomy\Model\TaxonInterface' => 'taxon',
+            ProductInterface::class => 'product',
+            TaxonInterface::class => 'taxon',
         ];
 
         $this->validator = Validation::createValidatorBuilder()

--- a/tests/lib/Layout/Resolver/Form/ConditionType/Mapper/ChannelTest.php
+++ b/tests/lib/Layout/Resolver/Form/ConditionType/Mapper/ChannelTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 #[CoversClass(Channel::class)]
 final class ChannelTest extends TestCase
 {
-    private MockObject&ChannelRepositoryInterface $channelRepository;
+    private ChannelRepositoryInterface&MockObject $channelRepository;
 
     private Channel $mapper;
 

--- a/tests/lib/Layout/Resolver/Form/ConditionType/Mapper/ResourceTypeTest.php
+++ b/tests/lib/Layout/Resolver/Form/ConditionType/Mapper/ResourceTypeTest.php
@@ -7,6 +7,10 @@ namespace Netgen\Layouts\Sylius\Tests\Layout\Resolver\Form\ConditionType\Mapper;
 use Netgen\Layouts\Sylius\Layout\Resolver\Form\ConditionType\Mapper\ResourceType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Model\Product;
+use Sylius\Component\Product\Model\ProductInterface;
+use Sylius\Component\Taxonomy\Model\Taxon;
+use Sylius\Component\Taxonomy\Model\TaxonInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 #[CoversClass(ResourceType::class)]
@@ -17,10 +21,10 @@ final class ResourceTypeTest extends TestCase
     protected function setUp(): void
     {
         $allowedResources = [
-            'Sylius\Component\Product\Model\ProductInterface' => 'product',
-            'Sylius\Component\Core\Model\Product' => 'product-test',
-            'Sylius\Component\Taxonomy\Model\TaxonInterface' => 'taxon',
-            'Sylius\Component\Taxonomy\Model\Taxon' => 'taxon_test',
+            ProductInterface::class => 'product',
+            Product::class => 'product-test',
+            TaxonInterface::class => 'taxon',
+            Taxon::class => 'taxon_test',
         ];
 
         $this->mapper = new ResourceType($allowedResources);
@@ -33,21 +37,14 @@ final class ResourceTypeTest extends TestCase
 
     public function testGetFormOptions(): void
     {
-        $typesList = [
-            'Product' => 'product',
-            'Product test' => 'product-test',
-            'Taxon' => 'taxon',
-            'Taxon test' => 'taxon_test',
-        ];
-
         self::assertSame(
             [
-                'choices' => $typesList,
-                'choice_translation_domain' => false,
-                'multiple' => true,
-                'expanded' => true,
+                'product',
+                'product-test',
+                'taxon',
+                'taxon_test',
             ],
-            $this->mapper->getFormOptions(),
+            $this->mapper->getFormOptions()['choices'],
         );
     }
 }

--- a/tests/lib/Layout/Resolver/Form/ConditionType/Mapper/ResourceTypeTest.php
+++ b/tests/lib/Layout/Resolver/Form/ConditionType/Mapper/ResourceTypeTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Tests\Layout\Resolver\Form\ConditionType\Mapper;
+
+use Netgen\Layouts\Sylius\Layout\Resolver\Form\ConditionType\Mapper\ResourceType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+
+#[CoversClass(ResourceType::class)]
+final class ResourceTypeTest extends TestCase
+{
+    private ResourceType $mapper;
+
+    protected function setUp(): void
+    {
+        $allowedResources = [
+            'Sylius\Component\Product\Model\ProductInterface' => 'product',
+            'Sylius\Component\Core\Model\Product' => 'product-test',
+            'Sylius\Component\Taxonomy\Model\TaxonInterface' => 'taxon',
+            'Sylius\Component\Taxonomy\Model\Taxon' => 'taxon_test',
+        ];
+
+        $this->mapper = new ResourceType($allowedResources);
+    }
+
+    public function testGetFormType(): void
+    {
+        self::assertSame(ChoiceType::class, $this->mapper->getFormType());
+    }
+
+    public function testGetFormOptions(): void
+    {
+        $typesList = [
+            'Product' => 'product',
+            'Product test' => 'product-test',
+            'Taxon' => 'taxon',
+            'Taxon test' => 'taxon_test',
+        ];
+
+        self::assertSame(
+            [
+                'choices' => $typesList,
+                'choice_translation_domain' => false,
+                'multiple' => true,
+                'expanded' => true,
+            ],
+            $this->mapper->getFormOptions(),
+        );
+    }
+}

--- a/tests/lib/Locale/LocaleProviderTest.php
+++ b/tests/lib/Locale/LocaleProviderTest.php
@@ -17,7 +17,7 @@ use function array_values;
 #[CoversClass(LocaleProvider::class)]
 final class LocaleProviderTest extends TestCase
 {
-    private MockObject&LocaleProviderInterface $syliusLocaleProviderMock;
+    private LocaleProviderInterface&MockObject $syliusLocaleProviderMock;
 
     private LocaleProvider $localeProvider;
 

--- a/tests/lib/Parameters/Form/Mapper/ChannelMapperTest.php
+++ b/tests/lib/Parameters/Form/Mapper/ChannelMapperTest.php
@@ -19,7 +19,7 @@ final class ChannelMapperTest extends TestCase
 {
     private ChannelMapper $mapper;
 
-    private MockObject&ChannelRepositoryInterface $repositoryMock;
+    private ChannelRepositoryInterface&MockObject $repositoryMock;
 
     protected function setUp(): void
     {

--- a/tests/lib/Parameters/ParameterType/ChannelTypeTest.php
+++ b/tests/lib/Parameters/ParameterType/ChannelTypeTest.php
@@ -22,7 +22,7 @@ final class ChannelTypeTest extends TestCase
 {
     use ParameterTypeTestTrait;
 
-    private MockObject&ChannelRepositoryInterface $repositoryMock;
+    private ChannelRepositoryInterface&MockObject $repositoryMock;
 
     protected function setUp(): void
     {

--- a/tests/lib/Validator/ChannelValidatorTest.php
+++ b/tests/lib/Validator/ChannelValidatorTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 #[CoversClass(ChannelValidator::class)]
 final class ChannelValidatorTest extends ValidatorTestCase
 {
-    private MockObject&ChannelRepositoryInterface $repositoryMock;
+    private ChannelRepositoryInterface&MockObject $repositoryMock;
 
     protected function setUp(): void
     {

--- a/tests/lib/Validator/Constraint/ResourceTypeTest.php
+++ b/tests/lib/Validator/Constraint/ResourceTypeTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Tests\Validator\Constraint;
+
+use Netgen\Layouts\Sylius\Validator\Constraint\ResourceType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResourceType::class)]
+final class ResourceTypeTest extends TestCase
+{
+    public function testValidatedBy(): void
+    {
+        $constraint = new ResourceType();
+        self::assertSame('nglayouts_sylius_resource_type', $constraint->validatedBy());
+    }
+}

--- a/tests/lib/Validator/ResourceTypeValidatorTest.php
+++ b/tests/lib/Validator/ResourceTypeValidatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Tests\Validator;
+
+use Netgen\Layouts\Sylius\Validator\Constraint\ResourceType;
+use Netgen\Layouts\Sylius\Validator\ResourceTypeValidator;
+use Netgen\Layouts\Tests\TestCase\ValidatorTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+#[CoversClass(ResourceTypeValidator::class)]
+final class ResourceTypeValidatorTest extends ValidatorTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->constraint = new ResourceType();
+    }
+
+    public function getValidator(): ConstraintValidatorInterface
+    {
+        $allowedResources = [
+            'Sylius\Component\Product\Model\ProductInterface' => 'product',
+            'Sylius\Component\Taxonomy\Model\TaxonInterface' => 'taxon',
+        ];
+
+        return new ResourceTypeValidator($allowedResources);
+    }
+
+    public function testValidateValid(): void
+    {
+        $this->assertValid(true, 'product');
+        $this->assertValid(true, 'taxon');
+    }
+
+    public function testValidateNull(): void
+    {
+        $this->assertValid(true, null);
+    }
+
+    public function testValidateInvalid(): void
+    {
+        $this->assertValid(false, 'category');
+    }
+
+    public function testValidateThrowsUnexpectedTypeExceptionWithInvalidConstraint(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->expectExceptionMessage('Expected argument of type "Netgen\\Layouts\\Sylius\\Validator\\Constraint\\ResourceType", "Symfony\\Component\\Validator\\Constraints\\NotBlank" given');
+
+        $this->constraint = new NotBlank();
+        $this->assertValid(true, 'value');
+    }
+
+    public function testValidateThrowsUnexpectedTypeExceptionWithInvalidValue(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->expectExceptionMessage('Expected argument of type "string", "array" given');
+
+        $this->assertValid(true, []);
+    }
+}

--- a/tests/lib/Validator/ResourceTypeValidatorTest.php
+++ b/tests/lib/Validator/ResourceTypeValidatorTest.php
@@ -8,6 +8,8 @@ use Netgen\Layouts\Sylius\Validator\Constraint\ResourceType;
 use Netgen\Layouts\Sylius\Validator\ResourceTypeValidator;
 use Netgen\Layouts\Tests\TestCase\ValidatorTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use Sylius\Component\Product\Model\ProductInterface;
+use Sylius\Component\Taxonomy\Model\TaxonInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -25,8 +27,8 @@ final class ResourceTypeValidatorTest extends ValidatorTestCase
     public function getValidator(): ConstraintValidatorInterface
     {
         $allowedResources = [
-            'Sylius\Component\Product\Model\ProductInterface' => 'product',
-            'Sylius\Component\Taxonomy\Model\TaxonInterface' => 'taxon',
+            ProductInterface::class => 'product',
+            TaxonInterface::class => 'taxon',
         ];
 
         return new ResourceTypeValidator($allowedResources);

--- a/tests/lib/Validator/SettingsValidatorFactory.php
+++ b/tests/lib/Validator/SettingsValidatorFactory.php
@@ -17,7 +17,7 @@ final class SettingsValidatorFactory implements ConstraintValidatorFactoryInterf
     /**
      * @param array<string, string> $settings
      */
-    public function __construct(private readonly array $settings)
+    public function __construct(private array $settings)
     {
         $this->baseValidatorFactory = new ConstraintValidatorFactory();
     }

--- a/tests/lib/Validator/SettingsValidatorFactory.php
+++ b/tests/lib/Validator/SettingsValidatorFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Tests\Validator;
+
+use Netgen\Layouts\Sylius\Validator\ResourceTypeValidator;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidatorFactory;
+use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+
+final class SettingsValidatorFactory implements ConstraintValidatorFactoryInterface
+{
+    private ConstraintValidatorFactory $baseValidatorFactory;
+
+    /**
+     * @param array<string, string> $settings
+     */
+    public function __construct(private readonly array $settings)
+    {
+        $this->baseValidatorFactory = new ConstraintValidatorFactory();
+    }
+
+    public function getInstance(Constraint $constraint): ConstraintValidatorInterface
+    {
+        return match ($constraint->validatedBy()) {
+            'nglayouts_sylius_resource_type' => new ResourceTypeValidator($this->settings),
+            default => $this->baseValidatorFactory->getInstance($constraint),
+        };
+    }
+}


### PR DESCRIPTION
In one of the projects we have a need to be able to map layout to all instances of a specific Sylius resource (product, taxon as well as any other eventual custom resources that are Sylius resources), in order to be able to build those pages (eg. product page) with layouts.

This PR introduces a new condition type that enables you to map a layout to all Sylius products or taxons. The list of available resources is done through semantic configuration so it can be easily extended in project to add new custom Sylius resources. Furthermore, Sylius event dispatcher has been decorated to dispatch generic events (eg. `sylius_resource_show`) and then we have a listener which resolves the resource and adds it to request so matching should be done automatically. Eg. if you create a new custom Sylius resource in your project, you only need to add it to the semantic configuration. Matching will automatically work.

Here's an example of semantic configuration (default one):

```
netgen_layouts_sylius:
    resource_type_condition:
        available_resources:
            Sylius\Component\Product\Model\ProductInterface: product
            Sylius\Component\Taxonomy\Model\TaxonInterface: taxon
```