### PR TITLE
Sylius page target type

### DIFF
--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -17,6 +17,7 @@ final class Configuration implements ConfigurationInterface
         /** @var \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $rootNode */
         $rootNode = $treeBuilder->getRootNode();
         $this->addResourceTypeConditionConfiguration($rootNode);
+        $this->addPageTargetConfiguration($rootNode);
 
         return $treeBuilder;
     }
@@ -28,6 +29,21 @@ final class Configuration implements ConfigurationInterface
                 ->arrayNode('resource_type_condition')
                     ->children()
                         ->arrayNode('available_resources')
+                            ->prototype('scalar')
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    private function addPageTargetConfiguration(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('page_target')
+                    ->children()
+                        ->arrayNode('available_pages')
                             ->prototype('scalar')
                             ->end()
                         ->end()

--- a/bundle/DependencyInjection/NetgenLayoutsSyliusExtension.php
+++ b/bundle/DependencyInjection/NetgenLayoutsSyliusExtension.php
@@ -45,6 +45,11 @@ final class NetgenLayoutsSyliusExtension extends Extension implements PrependExt
             'netgen_layouts.sylius.condition.resource_types',
             $config['resource_type_condition']['available_resources'],
         );
+
+        $container->setParameter(
+            'netgen_layouts.sylius.target.pages',
+            $config['page_target']['available_pages'],
+        );
     }
 
     public function prepend(ContainerBuilder $container): void

--- a/bundle/Resources/config/default_settings.yaml
+++ b/bundle/Resources/config/default_settings.yaml
@@ -6,10 +6,27 @@ resource_type_condition:
 page_target:
     available_pages:
         sylius_shop_homepage: homepage
+        sylius_shop_login: login
+        sylius_shop_register: register
+        sylius_shop_register_after_checkout: register_after_checkout
+        sylius_shop_request_password_reset_token: forgotten_password
+        sylius_shop_password_reset: password_reset
+        sylius_shop_contact_request: contact_request
         sylius_shop_cart_summary: cart_summary
         sylius_shop_order_thank_you: order_thank_you
         sylius_shop_order_show: order_show
-        sylius_shop_account_dashboard: account_dashboard
+        sylius_shop_product_review_index: product_reviews
+        sylius_shop_product_review_create: product_review_create
+        sylius_shop_checkout_start: checkout_start
+        sylius_shop_checkout_address: checkout_address
+        sylius_shop_checkout_select_shipping: checkout_select_shipping
+        sylius_shop_checkout_select_payment: checkout_select_payment
+        sylius_shop_checkout_complete: checkout_complete
         sylius_shop_account_order_index: account_orders
         sylius_shop_account_order_show: account_order_show
         sylius_shop_account_address_book_index: account_address_book
+        sylius_shop_account_address_book_create: account_address_book_create
+        sylius_shop_account_address_book_update: account_address_book_update
+        sylius_shop_account_dashboard: account_dashboard
+        sylius_shop_account_profile_update: account_profile_update
+        sylius_shop_account_change_password: account_change_password

--- a/bundle/Resources/config/default_settings.yaml
+++ b/bundle/Resources/config/default_settings.yaml
@@ -2,3 +2,14 @@ resource_type_condition:
     available_resources:
         Sylius\Component\Product\Model\ProductInterface: product
         Sylius\Component\Taxonomy\Model\TaxonInterface: taxon
+
+page_target:
+    available_pages:
+        sylius_shop_homepage: homepage
+        sylius_shop_cart_summary: cart_summary
+        sylius_shop_order_thank_you: order_thank_you
+        sylius_shop_order_show: order_show
+        sylius_shop_account_dashboard: account_dashboard
+        sylius_shop_account_order_index: account_orders
+        sylius_shop_account_order_show: account_order_show
+        sylius_shop_account_address_book_index: account_address_book

--- a/bundle/Resources/config/services/layout_resolver.yaml
+++ b/bundle/Resources/config/services/layout_resolver.yaml
@@ -44,6 +44,25 @@ services:
         tags:
             - { name: netgen_layouts.target_type.doctrine_handler, target_type: sylius_taxon }
 
+    netgen_layouts.sylius.layout_resolver.target_type.page:
+        class: Netgen\Layouts\Sylius\Layout\Resolver\TargetType\Page
+        arguments:
+            - "%netgen_layouts.sylius.target.pages%"
+        tags:
+            - { name: netgen_layouts.target_type, priority: 170 }
+
+    netgen_layouts.sylius.layout_resolver.target_handler.doctrine.sylius_page:
+        class: Netgen\Layouts\Sylius\Layout\Resolver\TargetHandler\Doctrine\Page
+        tags:
+            - { name: netgen_layouts.target_type.doctrine_handler, target_type: sylius_page }
+
+    netgen_layouts.sylius.layout_resolver.target_type.form_mapper.page:
+        class: Netgen\Layouts\Sylius\Layout\Resolver\Form\TargetType\Mapper\Page
+        arguments:
+            - "%netgen_layouts.sylius.target.pages%"
+        tags:
+            - { name: netgen_layouts.target_type.form_mapper, target_type: sylius_page }
+
     netgen_layouts.sylius.layout_resolver.condition_type.channel:
         class: Netgen\Layouts\Sylius\Layout\Resolver\ConditionType\Channel
         arguments:

--- a/bundle/Resources/config/services/validators.yaml
+++ b/bundle/Resources/config/services/validators.yaml
@@ -33,3 +33,10 @@ services:
             - "%netgen_layouts.sylius.condition.resource_types%"
         tags:
             - { name: validator.constraint_validator, alias: nglayouts_sylius_resource_type }
+
+    netgen_layouts.sylius.validator.page:
+        class: Netgen\Layouts\Sylius\Validator\PageValidator
+        arguments:
+            - "%netgen_layouts.sylius.target.pages%"
+        tags:
+            - { name: validator.constraint_validator, alias: nglayouts_sylius_page }

--- a/bundle/Resources/config/view/rule_target_view.yaml
+++ b/bundle/Resources/config/view/rule_target_view.yaml
@@ -13,3 +13,7 @@ view:
                 template: "@NetgenLayoutsSylius/admin/layout_resolver/target/value/taxon_product.html.twig"
                 match:
                     rule_target\type: sylius_taxon_product
+            sylius_page:
+                template: "@NetgenLayoutsSylius/admin/layout_resolver/target/value/page.html.twig"
+                match:
+                    rule_target\type: sylius_page

--- a/bundle/Resources/translations/nglayouts.en.yaml
+++ b/bundle/Resources/translations/nglayouts.en.yaml
@@ -9,6 +9,7 @@ query.sylius_taxon_products.sort_direction: 'Sort direction'
 layout_resolver.target.sylius_product: 'Sylius product'
 layout_resolver.target.sylius_taxon: 'Sylius taxon'
 layout_resolver.target.sylius_taxon_product: 'Sylius taxon products'
+layout_resolver.target.sylius_page: 'Sylius page'
 
 layout_resolver.condition.sylius_channel: 'Sylius channel'
 layout_resolver.condition.sylius_locale: 'Sylius locale'

--- a/bundle/Resources/translations/nglayouts_admin.en.yaml
+++ b/bundle/Resources/translations/nglayouts_admin.en.yaml
@@ -1,3 +1,4 @@
 layout_resolver.rule.target_header.sylius_product: 'Applied to Sylius product'
 layout_resolver.rule.target_header.sylius_taxon: 'Applied to Sylius taxon'
 layout_resolver.rule.target_header.sylius_taxon_product: 'Applied to Sylius taxon products'
+layout_resolver.rule.target_header.sylius_page: 'Applied to Sylius page'

--- a/bundle/Resources/translations/validators.en.yaml
+++ b/bundle/Resources/translations/validators.en.yaml
@@ -3,3 +3,4 @@ netgen_layouts.sylius.taxon.taxon_not_found: 'Taxon with ID %taxonId% does not e
 netgen_layouts.sylius.channel.channel_not_found: 'Channel %channel% does not exist.'
 netgen_layouts.sylius.locale.locale_not_found: 'Locale %locale% does not exist.'
 netgen_layouts.sylius.resource_type.type_not_found: 'Resource type %resource_type% does not exist.'
+netgen_layouts.sylius.page.page_not_found: 'Sylius page %page% does not exist.'

--- a/bundle/Resources/views/admin/layout_resolver/target/value/page.html.twig
+++ b/bundle/Resources/views/admin/layout_resolver/target/value/page.html.twig
@@ -1,0 +1,1 @@
+{{ target.value|capitalize|replace({'-': ' ', '_': ' '}) }}

--- a/lib/Layout/Resolver/Form/TargetType/Mapper/Page.php
+++ b/lib/Layout/Resolver/Form/TargetType/Mapper/Page.php
@@ -15,7 +15,7 @@ final class Page extends Mapper
     /**
      * @param array<string, string> $allowedPages
      */
-    public function __construct(private readonly array $allowedPages) {}
+    public function __construct(private array $allowedPages) {}
 
     public function getFormType(): string
     {

--- a/lib/Layout/Resolver/Form/TargetType/Mapper/Page.php
+++ b/lib/Layout/Resolver/Form/TargetType/Mapper/Page.php
@@ -15,9 +15,7 @@ final class Page extends Mapper
     /**
      * @param array<string, string> $allowedPages
      */
-    public function __construct(private readonly array $allowedPages)
-    {
-    }
+    public function __construct(private readonly array $allowedPages) {}
 
     public function getFormType(): string
     {

--- a/lib/Layout/Resolver/Form/TargetType/Mapper/Page.php
+++ b/lib/Layout/Resolver/Form/TargetType/Mapper/Page.php
@@ -7,6 +7,7 @@ namespace Netgen\Layouts\Sylius\Layout\Resolver\Form\TargetType\Mapper;
 use Netgen\Layouts\Layout\Resolver\Form\TargetType\Mapper;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
+use function array_values;
 use function str_replace;
 use function ucfirst;
 
@@ -25,25 +26,12 @@ final class Page extends Mapper
     public function getFormOptions(): array
     {
         return [
-            'choices' => $this->getPagesList(),
+            'choices' => array_values($this->allowedPages),
+            'choice_label' => fn (string $type): string => $this->humanizePage($type),
             'choice_translation_domain' => false,
             'multiple' => false,
             'expanded' => false,
         ];
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private function getPagesList(): array
-    {
-        $pageList = [];
-
-        foreach ($this->allowedPages as $page) {
-            $pageList[$this->humanizePage($page)] = $page;
-        }
-
-        return $pageList;
     }
 
     private function humanizePage(string $allowedPages): string

--- a/lib/Layout/Resolver/Form/TargetType/Mapper/Page.php
+++ b/lib/Layout/Resolver/Form/TargetType/Mapper/Page.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Layout\Resolver\Form\TargetType\Mapper;
+
+use Netgen\Layouts\Layout\Resolver\Form\TargetType\Mapper;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+
+use function str_replace;
+use function ucfirst;
+
+final class Page extends Mapper
+{
+    /**
+     * @param array<string, string> $allowedPages
+     */
+    public function __construct(private readonly array $allowedPages)
+    {
+    }
+
+    public function getFormType(): string
+    {
+        return ChoiceType::class;
+    }
+
+    public function getFormOptions(): array
+    {
+        return [
+            'choices' => $this->getPagesList(),
+            'choice_translation_domain' => false,
+            'multiple' => false,
+            'expanded' => false,
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getPagesList(): array
+    {
+        $pageList = [];
+
+        foreach ($this->allowedPages as $page) {
+            $pageList[$this->humanizePage($page)] = $page;
+        }
+
+        return $pageList;
+    }
+
+    private function humanizePage(string $allowedPages): string
+    {
+        return ucfirst(str_replace(['-', '_'], ' ', $allowedPages));
+    }
+}

--- a/lib/Layout/Resolver/TargetHandler/Doctrine/Page.php
+++ b/lib/Layout/Resolver/TargetHandler/Doctrine/Page.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Layout\Resolver\TargetHandler\Doctrine;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Types\Types;
+use Netgen\Layouts\Persistence\Doctrine\QueryHandler\TargetHandlerInterface;
+
+final class Page implements TargetHandlerInterface
+{
+    public function handleQuery(QueryBuilder $query, mixed $value): void
+    {
+        $query->andWhere(
+            $query->expr()->eq('rt.value', ':target_value'),
+        )
+        ->setParameter('target_value', $value, Types::STRING);
+    }
+}

--- a/lib/Layout/Resolver/TargetType/Page.php
+++ b/lib/Layout/Resolver/TargetType/Page.php
@@ -14,7 +14,7 @@ final class Page extends TargetType
     /**
      * @param array<string, string> $availablePages
      */
-    public function __construct(private readonly array $availablePages) {}
+    public function __construct(private array $availablePages) {}
 
     public static function getType(): string
     {

--- a/lib/Layout/Resolver/TargetType/Page.php
+++ b/lib/Layout/Resolver/TargetType/Page.php
@@ -14,9 +14,7 @@ final class Page extends TargetType
     /**
      * @param array<string, string> $availablePages
      */
-    public function __construct(private readonly array $availablePages)
-    {
-    }
+    public function __construct(private readonly array $availablePages) {}
 
     public static function getType(): string
     {

--- a/lib/Layout/Resolver/TargetType/Page.php
+++ b/lib/Layout/Resolver/TargetType/Page.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Layout\Resolver\TargetType;
+
+use Netgen\Layouts\Layout\Resolver\TargetType;
+use Netgen\Layouts\Sylius\Validator\Constraint as SyliusConstraints;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\Constraints;
+
+final class Page extends TargetType
+{
+    /**
+     * @param array<string, string> $availablePages
+     */
+    public function __construct(private readonly array $availablePages)
+    {
+    }
+
+    public static function getType(): string
+    {
+        return 'sylius_page';
+    }
+
+    public function getConstraints(): array
+    {
+        return [
+            new Constraints\NotBlank(),
+            new Constraints\Type(['type' => 'string']),
+            new SyliusConstraints\Page(),
+        ];
+    }
+
+    public function provideValue(Request $request): ?string
+    {
+        $route = $request->attributes->get('_route');
+
+        return $this->availablePages[$route] ?? null;
+    }
+}

--- a/lib/Validator/Constraint/Page.php
+++ b/lib/Validator/Constraint/Page.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Validator\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+final class Page extends Constraint
+{
+    public string $message = 'netgen_layouts.sylius.page.page_not_found';
+
+    public function validatedBy(): string
+    {
+        return 'nglayouts_sylius_page';
+    }
+}

--- a/lib/Validator/PageValidator.php
+++ b/lib/Validator/PageValidator.php
@@ -17,9 +17,7 @@ final class PageValidator extends ConstraintValidator
     /**
      * @param array<string, string> $allowedPages
      */
-    public function __construct(private readonly array $allowedPages)
-    {
-    }
+    public function __construct(private readonly array $allowedPages) {}
 
     public function validate(mixed $value, Constraint $constraint): void
     {

--- a/lib/Validator/PageValidator.php
+++ b/lib/Validator/PageValidator.php
@@ -17,7 +17,7 @@ final class PageValidator extends ConstraintValidator
     /**
      * @param array<string, string> $allowedPages
      */
-    public function __construct(private readonly array $allowedPages) {}
+    public function __construct(private array $allowedPages) {}
 
     public function validate(mixed $value, Constraint $constraint): void
     {

--- a/lib/Validator/PageValidator.php
+++ b/lib/Validator/PageValidator.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Validator;
+
+use Netgen\Layouts\Sylius\Validator\Constraint\Page;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+use function in_array;
+use function is_string;
+
+final class PageValidator extends ConstraintValidator
+{
+    /**
+     * @param array<string, string> $allowedPages
+     */
+    public function __construct(private readonly array $allowedPages)
+    {
+    }
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        if (!$constraint instanceof Page) {
+            throw new UnexpectedTypeException($constraint, Page::class);
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        if (!in_array($value, $this->allowedPages, true)) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('%page%', $value)
+                ->addViolation();
+        }
+    }
+}

--- a/tests/_fixtures/data.php
+++ b/tests/_fixtures/data.php
@@ -42,5 +42,8 @@ return [
         ['id' => 12, 'status' => 1, 'uuid' => 'd2311434-2d52-4c69-b016-ec4d2a8ea073', 'rule_id' => 6, 'type' => 'sylius_taxon_product', 'value' => 43],
         ['id' => 13, 'status' => 1, 'uuid' => 'faad2665-8bba-4751-9ea6-a69a0d5db13f', 'rule_id' => 6, 'type' => 'sylius_taxon_product', 'value' => 5],
         ['id' => 14, 'status' => 1, 'uuid' => '40aadd7e-01ae-49ea-80e2-fa1187b8342e', 'rule_id' => 7, 'type' => 'sylius_taxon_product', 'value' => 13],
+        ['id' => 15, 'status' => 1, 'uuid' => '40aadd7e-01ae-49ea-80e2-fa1187b8342e', 'rule_id' => 7, 'type' => 'sylius_page', 'value' => 'homepage'],
+        ['id' => 16, 'status' => 1, 'uuid' => '40aadd7e-01ae-49ea-80e2-fa1187b8342e', 'rule_id' => 7, 'type' => 'sylius_page', 'value' => 'cart_summary'],
+        ['id' => 17, 'status' => 1, 'uuid' => '40aadd7e-01ae-49ea-80e2-fa1187b8342e', 'rule_id' => 7, 'type' => 'sylius_page', 'value' => 'homepage'],
     ],
 ];

--- a/tests/_fixtures/data.php
+++ b/tests/_fixtures/data.php
@@ -42,8 +42,8 @@ return [
         ['id' => 12, 'status' => 1, 'uuid' => 'd2311434-2d52-4c69-b016-ec4d2a8ea073', 'rule_id' => 6, 'type' => 'sylius_taxon_product', 'value' => 43],
         ['id' => 13, 'status' => 1, 'uuid' => 'faad2665-8bba-4751-9ea6-a69a0d5db13f', 'rule_id' => 6, 'type' => 'sylius_taxon_product', 'value' => 5],
         ['id' => 14, 'status' => 1, 'uuid' => '40aadd7e-01ae-49ea-80e2-fa1187b8342e', 'rule_id' => 7, 'type' => 'sylius_taxon_product', 'value' => 13],
-        ['id' => 15, 'status' => 1, 'uuid' => '40aadd7e-01ae-49ea-80e2-fa1187b8342e', 'rule_id' => 7, 'type' => 'sylius_page', 'value' => 'homepage'],
-        ['id' => 16, 'status' => 1, 'uuid' => '40aadd7e-01ae-49ea-80e2-fa1187b8342e', 'rule_id' => 7, 'type' => 'sylius_page', 'value' => 'cart_summary'],
-        ['id' => 17, 'status' => 1, 'uuid' => '40aadd7e-01ae-49ea-80e2-fa1187b8342e', 'rule_id' => 7, 'type' => 'sylius_page', 'value' => 'homepage'],
+        ['id' => 15, 'status' => 1, 'uuid' => 'dbc264ac-3ade-4388-bc26-b82487d71699', 'rule_id' => 7, 'type' => 'sylius_page', 'value' => 'homepage'],
+        ['id' => 16, 'status' => 1, 'uuid' => '24136aac-c0b6-401d-9df6-f8c5ec19c1b2', 'rule_id' => 7, 'type' => 'sylius_page', 'value' => 'cart_summary'],
+        ['id' => 17, 'status' => 1, 'uuid' => 'bd338788-2ab5-45e0-aa53-f1bf6dba7d8f', 'rule_id' => 7, 'type' => 'sylius_page', 'value' => 'homepage'],
     ],
 ];

--- a/tests/_fixtures/data.php
+++ b/tests/_fixtures/data.php
@@ -44,6 +44,5 @@ return [
         ['id' => 14, 'status' => 1, 'uuid' => '40aadd7e-01ae-49ea-80e2-fa1187b8342e', 'rule_id' => 7, 'type' => 'sylius_taxon_product', 'value' => 13],
         ['id' => 15, 'status' => 1, 'uuid' => 'dbc264ac-3ade-4388-bc26-b82487d71699', 'rule_id' => 7, 'type' => 'sylius_page', 'value' => 'homepage'],
         ['id' => 16, 'status' => 1, 'uuid' => '24136aac-c0b6-401d-9df6-f8c5ec19c1b2', 'rule_id' => 7, 'type' => 'sylius_page', 'value' => 'cart_summary'],
-        ['id' => 17, 'status' => 1, 'uuid' => 'bd338788-2ab5-45e0-aa53-f1bf6dba7d8f', 'rule_id' => 7, 'type' => 'sylius_page', 'value' => 'homepage'],
     ],
 ];

--- a/tests/lib/Layout/Resolver/Form/TargetType/Mapper/PageTest.php
+++ b/tests/lib/Layout/Resolver/Form/TargetType/Mapper/PageTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Tests\Layout\Resolver\Form\TargetType\Mapper;
+
+use Netgen\Layouts\Sylius\Layout\Resolver\Form\TargetType\Mapper\Page;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+
+#[CoversClass(Page::class)]
+final class PageTest extends TestCase
+{
+    private Page $mapper;
+
+    protected function setUp(): void
+    {
+        $allowedPages = [
+            'sylius_shop_homepage' => 'homepage',
+            'sylius_shop_cart_summary' => 'cart_summary',
+            'sylius_shop_order_thank_you' => 'order_thank_you',
+            'sylius_shop_order_show' => 'order_show',
+        ];
+
+        $this->mapper = new Page($allowedPages);
+    }
+
+    public function testGetFormType(): void
+    {
+        self::assertSame(ChoiceType::class, $this->mapper->getFormType());
+    }
+
+    public function testGetFormOptions(): void
+    {
+        $pagesList = [
+            'Homepage' => 'homepage',
+            'Cart summary' => 'cart_summary',
+            'Order thank you' => 'order_thank_you',
+            'Order show' => 'order_show',
+        ];
+
+        self::assertSame(
+            [
+                'choices' => $pagesList,
+                'choice_translation_domain' => false,
+                'multiple' => false,
+                'expanded' => false,
+            ],
+            $this->mapper->getFormOptions(),
+        );
+    }
+}

--- a/tests/lib/Layout/Resolver/Form/TargetType/Mapper/PageTest.php
+++ b/tests/lib/Layout/Resolver/Form/TargetType/Mapper/PageTest.php
@@ -33,21 +33,14 @@ final class PageTest extends TestCase
 
     public function testGetFormOptions(): void
     {
-        $pagesList = [
-            'Homepage' => 'homepage',
-            'Cart summary' => 'cart_summary',
-            'Order thank you' => 'order_thank_you',
-            'Order show' => 'order_show',
-        ];
-
         self::assertSame(
             [
-                'choices' => $pagesList,
-                'choice_translation_domain' => false,
-                'multiple' => false,
-                'expanded' => false,
+                'homepage',
+                'cart_summary',
+                'order_thank_you',
+                'order_show',
             ],
-            $this->mapper->getFormOptions(),
+            $this->mapper->getFormOptions()['choices'],
         );
     }
 }

--- a/tests/lib/Layout/Resolver/TargetHandler/Doctrine/PageTest.php
+++ b/tests/lib/Layout/Resolver/TargetHandler/Doctrine/PageTest.php
@@ -23,7 +23,7 @@ final class PageTest extends TargetHandlerTestBase
         );
 
         self::assertCount(1, $rules);
-        self::assertSame(15, $rules[0]->id);
+        self::assertSame(7, $rules[0]->id);
     }
 
     protected function getTargetIdentifier(): string

--- a/tests/lib/Layout/Resolver/TargetHandler/Doctrine/PageTest.php
+++ b/tests/lib/Layout/Resolver/TargetHandler/Doctrine/PageTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Tests\Layout\Resolver\TargetHandler\Doctrine;
+
+use Netgen\Layouts\Persistence\Doctrine\QueryHandler\TargetHandlerInterface;
+use Netgen\Layouts\Persistence\Values\LayoutResolver\RuleGroup;
+use Netgen\Layouts\Persistence\Values\Value;
+use Netgen\Layouts\Sylius\Layout\Resolver\TargetHandler\Doctrine\Page;
+use Netgen\Layouts\Tests\Layout\Resolver\TargetHandler\Doctrine\TargetHandlerTestBase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Page::class)]
+final class PageTest extends TargetHandlerTestBase
+{
+    public function testMatchRules(): void
+    {
+        $rules = $this->handler->matchRules(
+            $this->handler->loadRuleGroup(RuleGroup::ROOT_UUID, Value::STATUS_PUBLISHED),
+            $this->getTargetIdentifier(),
+            'homepage',
+        );
+
+        self::assertCount(2, $rules);
+        self::assertSame(15, $rules[0]->id);
+        self::assertSame(17, $rules[1]->id);
+    }
+
+    protected function getTargetIdentifier(): string
+    {
+        return 'sylius_page';
+    }
+
+    protected function getTargetHandler(): TargetHandlerInterface
+    {
+        return new Page();
+    }
+
+    protected function insertDatabaseFixtures(string $fixturesPath): void
+    {
+        parent::insertDatabaseFixtures(__DIR__ . '/../../../../../_fixtures/data.php');
+    }
+}

--- a/tests/lib/Layout/Resolver/TargetHandler/Doctrine/PageTest.php
+++ b/tests/lib/Layout/Resolver/TargetHandler/Doctrine/PageTest.php
@@ -22,9 +22,8 @@ final class PageTest extends TargetHandlerTestBase
             'homepage',
         );
 
-        self::assertCount(2, $rules);
+        self::assertCount(1, $rules);
         self::assertSame(15, $rules[0]->id);
-        self::assertSame(17, $rules[1]->id);
     }
 
     protected function getTargetIdentifier(): string

--- a/tests/lib/Layout/Resolver/TargetType/PageTest.php
+++ b/tests/lib/Layout/Resolver/TargetType/PageTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Tests\Layout\Resolver\TargetType;
+
+use Netgen\Layouts\Sylius\Layout\Resolver\TargetType\Page;
+use Netgen\Layouts\Sylius\Tests\Validator\SettingsValidatorFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[CoversClass(Page::class)]
+final class PageTest extends TestCase
+{
+    private Page $targetType;
+
+    private ValidatorInterface $validator;
+
+    protected function setUp(): void
+    {
+        $allowedPages = [
+            'sylius_shop_homepage' => 'homepage',
+            'sylius_shop_cart_summary' => 'cart_summary',
+            'sylius_shop_order_thank_you' => 'order_thank_you',
+            'sylius_shop_order_show' => 'order_show',
+        ];
+
+        $this->validator = Validation::createValidatorBuilder()
+            ->setConstraintValidatorFactory(new SettingsValidatorFactory($allowedPages))
+            ->getValidator();
+
+        $this->targetType = new Page($allowedPages);
+    }
+
+    public function testGetType(): void
+    {
+        self::assertSame('sylius_page', $this->targetType::getType());
+    }
+
+    public function testValidationValid(): void
+    {
+        $errors = $this->validator->validate('homepage', $this->targetType->getConstraints());
+        self::assertCount(0, $errors);
+    }
+
+    public function testValidationInvalid(): void
+    {
+        $errors = $this->validator->validate('search_page', $this->targetType->getConstraints());
+        self::assertNotCount(0, $errors);
+    }
+
+    public function testProvideValue(): void
+    {
+        $request = Request::create('/');
+        $request->attributes->set('_route', 'sylius_shop_order_show');
+
+        self::assertSame('order_show', $this->targetType->provideValue($request));
+    }
+
+    public function testProvideValueWithNoRoute(): void
+    {
+        $request = Request::create('/');
+
+        self::assertNull($this->targetType->provideValue($request));
+    }
+}

--- a/tests/lib/Validator/Constraint/PageTest.php
+++ b/tests/lib/Validator/Constraint/PageTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Tests\Validator\Constraint;
+
+use Netgen\Layouts\Sylius\Validator\Constraint\Page;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Page::class)]
+final class PageTest extends TestCase
+{
+    public function testValidatedBy(): void
+    {
+        $constraint = new Page();
+        self::assertSame('nglayouts_sylius_page', $constraint->validatedBy());
+    }
+}

--- a/tests/lib/Validator/PageValidatorTest.php
+++ b/tests/lib/Validator/PageValidatorTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Tests\Validator;
+
+use Netgen\Layouts\Sylius\Validator\Constraint\Page;
+use Netgen\Layouts\Sylius\Validator\PageValidator;
+use Netgen\Layouts\Tests\TestCase\ValidatorTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+#[CoversClass(PageValidator::class)]
+final class PageValidatorTest extends ValidatorTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->constraint = new Page();
+    }
+
+    public function getValidator(): ConstraintValidatorInterface
+    {
+        $allowedPages = [
+            'sylius_shop_homepage' => 'homepage',
+            'sylius_shop_cart_summary' => 'cart_summary',
+            'sylius_shop_order_thank_you' => 'order_thank_you',
+            'sylius_shop_order_show' => 'order_show',
+        ];
+
+        return new PageValidator($allowedPages);
+    }
+
+    public function testValidateValid(): void
+    {
+        $this->assertValid(true, 'homepage');
+        $this->assertValid(true, 'cart_summary');
+    }
+
+    public function testValidateNull(): void
+    {
+        $this->assertValid(true, null);
+    }
+
+    public function testValidateInvalid(): void
+    {
+        $this->assertValid(false, 'search_page');
+    }
+
+    public function testValidateThrowsUnexpectedTypeExceptionWithInvalidConstraint(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->expectExceptionMessage('Expected argument of type "Netgen\\Layouts\\Sylius\\Validator\\Constraint\\Page", "Symfony\\Component\\Validator\\Constraints\\NotBlank" given');
+
+        $this->constraint = new NotBlank();
+        $this->assertValid(true, 'value');
+    }
+
+    public function testValidateThrowsUnexpectedTypeExceptionWithInvalidValue(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->expectExceptionMessage('Expected argument of type "string", "array" given');
+
+        $this->assertValid(true, []);
+    }
+}

--- a/tests/lib/Validator/SettingsValidatorFactory.php
+++ b/tests/lib/Validator/SettingsValidatorFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Netgen\Layouts\Sylius\Tests\Validator;
 
+use Netgen\Layouts\Sylius\Validator\PageValidator;
 use Netgen\Layouts\Sylius\Validator\ResourceTypeValidator;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorFactory;
@@ -26,6 +27,7 @@ final class SettingsValidatorFactory implements ConstraintValidatorFactoryInterf
     {
         return match ($constraint->validatedBy()) {
             'nglayouts_sylius_resource_type' => new ResourceTypeValidator($this->settings),
+            'nglayouts_sylius_page' => new PageValidator($this->settings),
             default => $this->baseValidatorFactory->getInstance($constraint),
         };
     }


### PR DESCRIPTION
In one of the projects we have a need to be able to map layout to specific Sylius static pages (such as homepage, basket page, checkout page etc.) and to avoid doing this using Symfony routes (which is not editor friendly), we need a target for a predefined set of pages.

This PR introduces a new target type that enables you to map a layout to a list of available Sylius pages. The list is done through semantic configuration so it can be easily extended in project to add new custom Symfony routes.

**Note:** This PR depends on another PR as it uses some code that has been introduced there. It has to either be merged into that branch (as it's configured) or merged into master after this parent one gets merged.

Here's an example of semantic configuration (default one):

```
netgen_layouts_sylius:
    page_target:
        available_pages:
            sylius_shop_homepage: homepage
            sylius_shop_cart_summary: cart_summary
            sylius_shop_order_thank_you: order_thank_you
            sylius_shop_order_show: order_show
            sylius_shop_account_dashboard: account_dashboard
            sylius_shop_account_order_index: account_orders
            sylius_shop_account_order_show: account_order_show
            sylius_shop_account_address_book_index: account_address_book
```