### PR TITLE
Avoid using functions for DEFINED test

### DIFF
--- a/bundle/Resources/views/admin/layout_resolver/target/value/product.html.twig
+++ b/bundle/Resources/views/admin/layout_resolver/target/value/product.html.twig
@@ -1,1 +1,3 @@
-{{ nglayouts_sylius_product_name(target.value) ?? '(INVALID PRODUCT)' }}
+{% set product_name = nglayouts_sylius_product_name(target.value) %}
+
+{{ product_name ?? '(INVALID PRODUCT)' }}


### PR DESCRIPTION
`??` operator internally uses `is defined`, which supports only simple variables, so it's not possible to use function there. This PR sets the function result into a variable before using it with the `??` operator.