### PR TITLE
Require layouts-standard repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     "require": {
         "php": "^8.4",
         "netgen/layouts-core": "~2.0.0",
+        "netgen/layouts-standard": "~2.0.0",
         "netgen/content-browser-sylius": "^2.0",
         "doctrine/orm": "^3.6",
         "sylius/sylius": "^2.2",
-        "sylius/resource-bundle": "^1.14",
-        "netgen/layouts-standard": "~2.0.0"
+        "sylius/resource-bundle": "^1.14"
     },
     "require-dev": {
         "netgen/layouts-coding-standard": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "netgen/content-browser-sylius": "^2.0",
         "doctrine/orm": "^3.6",
         "sylius/sylius": "^2.2",
-        "sylius/resource-bundle": "^1.14"
+        "sylius/resource-bundle": "^1.14",
+        "netgen/layouts-standard": "~2.0.0"
     },
     "require-dev": {
         "netgen/layouts-coding-standard": "^3.0",


### PR DESCRIPTION
`netgen/layouts-sylius` registers Sylius **TwigHooks** pointing at `@NetgenLayoutsStandard/*` templates but doesn't require `netgen/layouts-standard`. Consequently, a fresh install hits a `HookRenderException` on every storefront render.