### PR TITLE
Add data migration for the 1.4 taxon target type rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ composer require netgen/layouts-sylius
 
 Symfony Flex will automatically enable the bundle and import the routes.
 
+### Upgrading from Netgen Layouts 1.4
+
+Version 2.0 renamed the taxon rule target types: 1.4's `sylius_single_taxon` (exact match) is
+now `sylius_taxon`, and 1.4's `sylius_taxon` (subtree match) is now `sylius_taxon_tree`.
+Existing rule targets need a one-time rename, shipped as a Doctrine migration:
+
+```bash
+php bin/console doctrine:migrations:migrate --configuration=vendor/netgen/layouts-sylius/migrations/doctrine.yaml
+```
+
+The migration only acts on databases still carrying the 1.4 names, so it is safe to run it
+unconditionally as part of the upgrade.
+
 ### Configure the main layout
 
 Due to how Netgen Layouts works, your main layout template needs to wrap the

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     "autoload": {
         "psr-4": {
             "Netgen\\Layouts\\Sylius\\": "lib/",
+            "Netgen\\Layouts\\Sylius\\Migrations\\": "migrations/",
             "Netgen\\Bundle\\LayoutsSyliusBundle\\": "bundle/"
         }
     },

--- a/migrations/Doctrine/Version020000.php
+++ b/migrations/Doctrine/Version020000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Layouts\Sylius\Migrations\Doctrine;
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+use function is_numeric;
+
+/**
+ * Renames the taxon rule target types stored by 1.4 to their 2.0 names: `sylius_single_taxon`
+ * (exact match) became `sylius_taxon`, and `sylius_taxon` (subtree match) became
+ * `sylius_taxon_tree`. The statement order is load-bearing — swapped, the second rename would
+ * feed the first one's input. The guard skips databases already on the 2.0 names, where
+ * `sylius_taxon` rows are renamed exact-match targets that the first statement would corrupt.
+ */
+final class Version020000 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'Migration can only be executed safely on MySQL.');
+
+        $legacyRowCount = $this->connection->fetchOne("SELECT COUNT(*) FROM nglayouts_rule_target WHERE type = 'sylius_single_taxon'");
+        $this->skipIf(!is_numeric($legacyRowCount) || (int) $legacyRowCount === 0, 'Taxon rule targets already use their 2.0 type names.');
+
+        $this->addSql("UPDATE nglayouts_rule_target SET type = 'sylius_taxon_tree' WHERE type = 'sylius_taxon'");
+        $this->addSql("UPDATE nglayouts_rule_target SET type = 'sylius_taxon' WHERE type = 'sylius_single_taxon'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof MySQLPlatform, 'Migration can only be executed safely on MySQL.');
+
+        $this->addSql("UPDATE nglayouts_rule_target SET type = 'sylius_single_taxon' WHERE type = 'sylius_taxon'");
+        $this->addSql("UPDATE nglayouts_rule_target SET type = 'sylius_taxon' WHERE type = 'sylius_taxon_tree'");
+    }
+}

--- a/migrations/doctrine.yaml
+++ b/migrations/doctrine.yaml
@@ -1,0 +1,7 @@
+migrations_paths:
+    Netgen\Layouts\Sylius\Migrations\Doctrine: Doctrine
+
+table_storage:
+    table_name: nglayouts_migration_versions
+
+transactional: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,3 +4,4 @@ parameters:
     paths:
         - lib
         - bundle
+        - migrations


### PR DESCRIPTION
Add data migration for the 1.4 taxon target type rename

Version 2.0 renamed the two taxon target types: 1.4's SingleTaxon (sylius_single_taxon, exact match) became Taxon (sylius_taxon), and 1.4's Taxon (sylius_taxon, matched against the taxon and its ancestors) became TaxonTree (sylius_taxon_tree). The rename was announced by the @deprecated notes on the 1.4 classes in lib/Layout/Resolver/TargetType/, but nothing updates the type names already stored in nglayouts_rule_target, and there is no upgrade note covering it.

That leaves an upgraded installation quietly broken in two ways. Rows still typed sylius_single_taxon reference a type that no longer exists, so those rules never match again and the admin shows them as invalid targets. Rows typed sylius_taxon keep matching, but with the new exact-match semantics — a rule that used to cover a whole subtree silently shrinks to a single taxon. Neither case produces an error; pages just resolve the wrong layouts.

This PR adds a Doctrine data migration for the rename, following the layouts-core migrations setup (own migrations/doctrine.yaml, the shared nglayouts_migration_versions table, MySQL-only). The subtree rename runs first on purpose: the two names overlap across versions, so the reverse order would rename subtree targets twice. The migration skips databases already carrying the 2.0 names — there, sylius_taxon rows are renamed exact-match targets that the first statement would corrupt — so it is safe to run unconditionally, and the README now documents the upgrade step.

To run it:

`php bin/console doctrine:migrations:migrate --configuration=vendor/netgen/layouts-sylius/migrations/doctrine.yaml`

On a database with 1.4 rule targets the two renames apply; anywhere else it skips with "Taxon rule targets already use their 2.0 type names." and changes nothing.